### PR TITLE
Upgrade to VS 2019 and minors changes for MSVC

### DIFF
--- a/include/common.hpp
+++ b/include/common.hpp
@@ -115,9 +115,9 @@ enum class side_of_market {
 };
 
 enum class side_of_trade {
-    buy = 1,
+    buy = 2,
     sell = -1,
-    both = 0
+    both = 3
 };
 
 using order_exec_cb_type = std::function<

--- a/src/orderbook/query.cpp
+++ b/src/orderbook/query.cpp
@@ -306,8 +306,11 @@ SOB_CLASS::_total_depth() const
     using FirstChain =
         typename std::conditional<AON, limit_chain_type, ChainTy>::type;
 
-    auto pred = AON  ? [](const limit_bndl& b){ return order::is_AON(b); }
-                     : [](const limit_bndl& b){ return order::is_not_AON(b); };
+	auto lambda_is_AON =[](const limit_bndl& b) { return order::is_AON(b); };
+    auto lambda_is_not_AON = [](const limit_bndl& b){ return order::is_not_AON(b); };
+	
+	auto pred = AON ? std::function<bool(const limit_bndl& b)>(lambda_is_AON) : std::function<bool(const limit_bndl& b)>(lambda_is_not_AON);
+	
 
     std::lock_guard<std::mutex> lock(_master_mtx);
     /* --- CRITICAL SECTION --- */

--- a/vsbuild/FunctionalTest/FunctionalTest.vcxproj
+++ b/vsbuild/FunctionalTest/FunctionalTest.vcxproj
@@ -22,32 +22,32 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{08E35851-1ABA-4709-AFAF-36CF162F499F}</ProjectGuid>
     <RootNamespace>FunctionalTest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/vsbuild/PerformanceTest/PerformanceTest.vcxproj
+++ b/vsbuild/PerformanceTest/PerformanceTest.vcxproj
@@ -22,32 +22,32 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{287DFD50-D3E1-4E84-97E9-745EA485CE00}</ProjectGuid>
     <RootNamespace>PerformanceTest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/vsbuild/SimpleOrderbook/SimpleOrderbook.vcxproj
+++ b/vsbuild/SimpleOrderbook/SimpleOrderbook.vcxproj
@@ -21,32 +21,32 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1918A139-99C4-4A6D-AEEC-9298FB770F3D}</ProjectGuid>
     <RootNamespace>SimpleOrderbook</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
Hi, 

Thank you for this great project ! I really like the design and performance of this orderbook.

Currently the orderbook doesn't compile directly on VS 2019, this small PR fixes it.  
 
There was two problems:  

- MSVC wasn't able to differentiate between [aon::chain< bool >size() ](https://github.com/jeog/SimpleOrderbook/blob/e58269d5fa3c6b7544cf02abdfdfcd455c9b85df/src/orderbook/specials.tpp#L676) and [aon::chain<side_of_trade>size() ](https://github.com/jeog/SimpleOrderbook/blob/e58269d5fa3c6b7544cf02abdfdfcd455c9b85df/src/orderbook/specials.tpp#L681) because side_of_trade::buy/both were incorrectly implicitly converted by MSVC to true/false. The error message was : 

  Error C2668 'sob::detail::chain<sob::detail::sob_types::aon_chain_type,false>::size': ambiguous call to overloaded function SimpleOrderbook ...\SimpleOrderbook\src\orderbook\query.cpp 322 

- MSVC wasn't able to compile the [predicate ](https://github.com/jeog/SimpleOrderbook/blob/e58269d5fa3c6b7544cf02abdfdfcd455c9b85df/src/orderbook/query.cpp#L309) in _total_depth() . 
One example of several errors message during compilation was:
Error C2446 ':': no conversion from 'sob::SimpleOrderbook::SimpleOrderbookBase::_total_depth::<lambda_7c49c8eb306abb18fab89ca2523ab779>' to 'sob::SimpleOrderbook::SimpleOrderbookBase::_total_depth::<lambda_5192d9762e9676df327f3ba78f19d1e6>' SimpleOrderbook .....\SimpleOrderbook\src\orderbook\query.cpp 314 

I believe this will have no impact for other compilers but feel free to reject if this is the case. 
This PR pass the functional test on VS 2019.

Thanks,

MF

